### PR TITLE
Set table_cell inline width based on data-colwidth attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@policyco/prosemirror-tables",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@policyco/prosemirror-tables",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "prosemirror-keymap": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@policyco/prosemirror-tables",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "PolicyCo's version of ProseMirror's rowspan/colspan tables component",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -42,7 +42,10 @@ function setCellAttrs(node: Node, extraAttrs: Attrs): Attrs {
   if (node.attrs.rowspan != 1) attrs.rowspan = node.attrs.rowspan;
   if (node.attrs.colwidth) {
     attrs['data-colwidth'] = node.attrs.colwidth.join(',');
-    const width = node.attrs.colwidth.reduce((acc: number, w: number) => acc + w, 0);
+    const width = node.attrs.colwidth.reduce(
+      (acc: number, w: number) => acc + w,
+      0,
+    );
     if (width > 0) {
       attrs.style = `width: ${width}px;`;
     }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -40,8 +40,13 @@ function setCellAttrs(node: Node, extraAttrs: Attrs): Attrs {
   const attrs: MutableAttrs = {};
   if (node.attrs.colspan != 1) attrs.colspan = node.attrs.colspan;
   if (node.attrs.rowspan != 1) attrs.rowspan = node.attrs.rowspan;
-  if (node.attrs.colwidth)
+  if (node.attrs.colwidth) {
     attrs['data-colwidth'] = node.attrs.colwidth.join(',');
+    const width = node.attrs.colwidth.reduce((acc: number, w: number) => acc + w, 0);
+    if (width > 0) {
+      attrs.style = `width: ${width}px;`;
+    }
+  }
   for (const prop in extraAttrs) {
     const setter = extraAttrs[prop].setDOMAttr;
     if (setter) setter(node.attrs[prop], attrs);
@@ -99,7 +104,7 @@ export interface TableNodesOptions {
    * Additional attributes to add to cells. Maps attribute names to
    * objects with the following properties:
    */
-  cellAttributes: { [key: string]: CellAttributes };
+  cellAttributes?: { [key: string]: CellAttributes };
 
   /**
    * The max width allowed of the table. When resizing the table, it will not be allowed to grow larger than this value.


### PR DESCRIPTION
In the schema, add logic that will set the inline style of the cell width based on the node.attr.colwidth value.

The table view uses this attr to insert a colgroup. Adding it in the schema supports more use of the table node spec where a view is not needed.